### PR TITLE
/dev/.su.d still detectable

### DIFF
--- a/src/core/patcher.py
+++ b/src/core/patcher.py
@@ -90,6 +90,8 @@ class Patcher:
         "SuperSU":                                      "SuperNU",
         "daemonsu":                                     "daemonnu",
         "sudaemon":                                     "nudaemon",
+        "/dev/.su.d":                                   "/dev/.nu.d",
+        "/dev/.su.d.complete":                          "/dev/.nu.d.complete",
 
         #sukernel
         "sukernel":                                     "nukernel",


### PR DESCRIPTION
Several applications mark the device as rooted if they can access `/dev/.su.d`. In most cases, solely renaming the file to `/dev/.nu.d` does the job.